### PR TITLE
Move to GH org camunda

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -15,7 +15,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: camunda-cloud/action-add-to-project@v1
+      - uses: camunda/action-add-to-project@v1
         with:
           project-alias: sre
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @camunda/sre

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then, enable it with:
 plugin "camunda-saas" {
   enabled = true
   version = "v1.1.0"
-  source  = "github.com/camunda-cloud/tflint-ruleset-camunda-saas"
+  source  = "github.com/camunda/tflint-ruleset-camunda-saas"
 }
 ```
 
@@ -47,7 +47,7 @@ Open the [documentation](./docs/README.md) to get the list of rules.
    plugin "camunda-saas" {
      enabled = true
      version = "vX.Y.Z"
-     source  = "github.com/camunda-cloud/tflint-ruleset-camunda-saas"
+     source  = "github.com/camunda/tflint-ruleset-camunda-saas"
    }
    ```
 

--- a/rules/google_iam_bindings.go
+++ b/rules/google_iam_bindings.go
@@ -28,7 +28,7 @@ func (r *GoogleIamAuthoritative) Severity() tflint.Severity {
 }
 
 func (r *GoogleIamAuthoritative) Link() string {
-	return "https://github.com/camunda-cloud/tflint-ruleset-camunda-saas/blob/master/docs/rules/camunda_gcp_iam_authoritative.md"
+	return "https://github.com/camunda/tflint-ruleset-camunda-saas/blob/master/docs/rules/camunda_gcp_iam_authoritative.md"
 }
 
 func (r *GoogleIamAuthoritative) Check(runner tflint.Runner) error {


### PR DESCRIPTION
Migrate to GH org `camunda`, all `camunda-cloud` things are replaced by `camunda`

## Related issues

* https://github.com/camunda/team-sre/issues/1173
https://github.com/camunda/team-sre/issues/1329